### PR TITLE
Rodar migrations a cada novo deploy no Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: rake db:migrate
 web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
- Tratativa para sempre rodar as `migrations` a cada novo deploy no Heroku

Fonte: [Heroku Dev Center](https://devcenter.heroku.com/articles/release-phase#specifying-release-phase-tasks)