### PR TITLE
Ajusta aviso de depreciação de `fixture_path`

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -83,9 +83,6 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include FactoryBot::Syntax::Methods
 
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.use_transactional_fixtures = true
-
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 end


### PR DESCRIPTION
Ao rodar `rake spec` na branch `main`, o aviso abaixo é retornado.
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/3c66426a-36ba-48e3-bf2b-8987dce59f2a">
Esta pull request corrige o problema mencionado.